### PR TITLE
Fix the double authentication problem in all deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
     from masks import MaskClient
     
-    sandbox = from_profile("nsls2", "dask", username=None)\["chx"\]["sandbox"]
+    sandbox = from_profile("nsls2", "dask")\["chx"\]["sandbox"]
     mask_clilent = MaskClient(sandbox)
 
 

--- a/sparsify.py
+++ b/sparsify.py
@@ -18,7 +18,7 @@ from tiled.structures.sparse import COOStructure
 EXPORT_PATH = Path("/nsls2/data/dssi/scratch/prefect-outputs/chx/")
 
 # distributed_client = distributed.Client(n_workers=1, threads_per_worker=1, processes=False)
-tiled_client = from_profile("nsls2", "dask", username=None)["chx"]
+tiled_client = from_profile("nsls2", "dask")["chx"]
 tiled_client_chx = tiled_client["raw"]
 tiled_client_sandbox = tiled_client["sandbox"]
 
@@ -96,7 +96,7 @@ def write_sparse_chunk(data, dataset_id=None, block_info=None, dataset=None):
 
     if block_info:
         if dataset is None:
-            tiled_client = from_profile("nsls2", "dask", username=None)["chx"]
+            tiled_client = from_profile("nsls2", "dask")["chx"]
             tiled_client_sandbox = tiled_client["sandbox"]
             dataset = tiled_client_sandbox[dataset_id]
 

--- a/test_sparsify.py
+++ b/test_sparsify.py
@@ -14,7 +14,7 @@ from tiled.queries import Key
 from prefect.testing.utilities import prefect_test_harness
 
 DATA_DIRECTORY = Path("/nsls2/data/chx/legacy/Compressed_Data")
-tiled_client = from_profile("nsls2", "dask", username=None)["chx"]
+tiled_client = from_profile("nsls2", "dask")["chx"]
 tiled_client_chx = tiled_client["raw"]
 tiled_client_sandbox = tiled_client["sandbox"]
 mask_client = MaskClient(tiled_client_sandbox)


### PR DESCRIPTION
This PR removes the use if `username` in `from_profile` for all deployments and documentation.
This was detected and tested in a previous PR (#6) for just one deployment. This will avoid bumping into the same issue while running the other deployments for CHX.